### PR TITLE
Update to ML.NET 1.0.0-preview

### DIFF
--- a/XamlBrewer.Uwp.MachineLearningSample/Models/BinaryClassification/BinaryClassificationModel.cs
+++ b/XamlBrewer.Uwp.MachineLearningSample/Models/BinaryClassification/BinaryClassificationModel.cs
@@ -16,7 +16,7 @@ namespace XamlBrewer.Uwp.MachineLearningSample.Models
         public PredictionModel<BinaryClassificationData, BinaryClassificationPrediction> BuildAndTrain(string trainingDataPath, IEstimator<ITransformer> algorithm)
         {
             IEstimator<ITransformer> pipeline =
-                MLContext.Transforms.ReplaceMissingValues("FixedAcidity", replacementKind: MissingValueReplacingEstimator.ColumnOptions.ReplacementMode.Mean)
+                MLContext.Transforms.ReplaceMissingValues("FixedAcidity", replacementMode: MissingValueReplacingEstimator.ReplacementMode.Mean)
                 .Append(MLContext.FloatToBoolLabelNormalizer())
                 .Append(MLContext.Transforms.Concatenate("Features",
                     new[]
@@ -50,8 +50,9 @@ namespace XamlBrewer.Uwp.MachineLearningSample.Models
         public void Save(PredictionModel<BinaryClassificationData, BinaryClassificationPrediction> model, string modelName)
         {
             var storageFolder = ApplicationData.Current.LocalFolder;
-            using (var fs = new FileStream(Path.Combine(storageFolder.Path, modelName), FileMode.Create, FileAccess.Write, FileShare.Write))
-                MLContext.Model.Save(model.Transformer, fs);
+            string modelPath = Path.Combine(storageFolder.Path, modelName);
+
+            MLContext.Model.Save(model.Transformer, inputSchema: null, filePath: modelPath);
         }
 
         public CalibratedBinaryClassificationMetrics Evaluate(PredictionModel<BinaryClassificationData, BinaryClassificationPrediction> model, string testDataLocation)

--- a/XamlBrewer.Uwp.MachineLearningSample/Models/BinaryClassification/MlContextExtensions.cs
+++ b/XamlBrewer.Uwp.MachineLearningSample/Models/BinaryClassification/MlContextExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.ML;
+using Microsoft.ML.Experimental;
 using Microsoft.ML.Transforms;
 using System;
 using System.Linq;
@@ -12,8 +13,8 @@ namespace XamlBrewer.Uwp.MachineLearningSample.Models
         /// </summary>
         public static IEstimator<ITransformer> FloatToBoolLabelNormalizer(this MLContext mLContext)
         {
-            var normalizer = mLContext.Transforms.Normalize(
-                new NormalizingEstimator.BinningColumnOptions(outputColumnName: "Label", numBins: 2));
+            var normalizer = mLContext.Transforms.NormalizeBinning(
+                outputColumnName: "Label", maximumBinCount: 2);
 
             return normalizer.Append(mLContext.Transforms.CustomMapping(new MapFloatToBool().GetMapping(), "MapFloatToBool"));
         }

--- a/XamlBrewer.Uwp.MachineLearningSample/Models/BinaryClassification/MlContextExtensions.cs
+++ b/XamlBrewer.Uwp.MachineLearningSample/Models/BinaryClassification/MlContextExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.ML;
-using Microsoft.ML.Experimental;
 using Microsoft.ML.Transforms;
 using System;
 using System.Linq;

--- a/XamlBrewer.Uwp.MachineLearningSample/Models/Clustering/ClusteringModel.cs
+++ b/XamlBrewer.Uwp.MachineLearningSample/Models/Clustering/ClusteringModel.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Data.DataView;
-using Microsoft.ML;
+﻿using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Trainers;
 using System.Collections.Generic;
@@ -44,7 +43,7 @@ namespace XamlBrewer.Uwp.MachineLearningSample.Models
             Pipeline = _mlContext.Transforms.Concatenate("Features", new[] { "AnnualIncome", "SpendingScore" })
                 .Append(_mlContext.Clustering.Trainers.KMeans(
                     featureColumnName: "Features",
-                    clustersCount: 5));
+                    numberOfClusters: 5));
         }
 
         public void Train(IDataView trainingDataView)
@@ -55,14 +54,9 @@ namespace XamlBrewer.Uwp.MachineLearningSample.Models
         public void Save(string modelName)
         {
             var storageFolder = ApplicationData.Current.LocalFolder;
-            using (var fs = new FileStream(
-                    Path.Combine(storageFolder.Path, modelName),
-                    FileMode.Create,
-                    FileAccess.Write,
-                    FileShare.Write))
-            {
-                Model.SaveTo(_mlContext, fs);
-            }
+            string modelPath = Path.Combine(storageFolder.Path, modelName);
+
+            _mlContext.Model.Save(Model, inputSchema: null, filePath: modelPath);
         }
 
         public IEnumerable<ClusteringPrediction> Predict(IDataView dataView)
@@ -73,7 +67,7 @@ namespace XamlBrewer.Uwp.MachineLearningSample.Models
 
         public ClusteringPrediction Predict(ClusteringData clusteringData)
         {
-            var predictionFunc = Model.CreatePredictionEngine<ClusteringData, ClusteringPrediction>(_mlContext);
+            var predictionFunc = _mlContext.Model.CreatePredictionEngine<ClusteringData, ClusteringPrediction>(Model);
             return predictionFunc.Predict(clusteringData);
         }
     }

--- a/XamlBrewer.Uwp.MachineLearningSample/Models/MulticlassClassification/MulticlassClassificationModel.cs
+++ b/XamlBrewer.Uwp.MachineLearningSample/Models/MulticlassClassification/MulticlassClassificationModel.cs
@@ -21,7 +21,7 @@ namespace XamlBrewer.Uwp.MachineLearningSample.Models
             // Main algorithm
             // .Append(MLContext.MulticlassClassification.Trainers.StochasticDualCoordinateAscent())
             // or
-                .Append(MLContext.MulticlassClassification.Trainers.LogisticRegression())
+                .Append(MLContext.MulticlassClassification.Trainers.LbfgsMaximumEntropy())
             // or
             // .Append(MLContext.MulticlassClassification.Trainers.NaiveBayes()) // yields weird metrics...
 
@@ -40,15 +40,12 @@ namespace XamlBrewer.Uwp.MachineLearningSample.Models
         public void Save(string modelName)
         {
             var storageFolder = ApplicationData.Current.LocalFolder;
-            using (var fs = new FileStream(
-                Path.Combine(storageFolder.Path, modelName),
-                FileMode.Create,
-                FileAccess.Write,
-                FileShare.Write))
-                MLContext.Model.Save(Model.Transformer, fs);
+            string modelPath = Path.Combine(storageFolder.Path, modelName);
+
+            MLContext.Model.Save(Model.Transformer, inputSchema: null, filePath: modelPath);
         }
 
-        public MultiClassClassifierMetrics Evaluate(string testDataPath)
+        public MulticlassClassificationMetrics Evaluate(string testDataPath)
         {
             var testData = MLContext.Data.LoadFromTextFile<MulticlassClassificationData>(testDataPath);
 

--- a/XamlBrewer.Uwp.MachineLearningSample/Models/PredictionModel.cs
+++ b/XamlBrewer.Uwp.MachineLearningSample/Models/PredictionModel.cs
@@ -9,7 +9,7 @@ namespace XamlBrewer.Uwp.MachineLearningSample.Models
         public PredictionModel(MLContext mlContext, ITransformer transformer)
         {
             Transformer = transformer;
-            Engine = Transformer.CreatePredictionEngine<TSrc, TDst>(mlContext);
+            Engine = mlContext.Model.CreatePredictionEngine<TSrc, TDst>(Transformer);
         }
 
         public ITransformer Transformer { get; }

--- a/XamlBrewer.Uwp.MachineLearningSample/Models/Recommendation/RecommendationModel.cs
+++ b/XamlBrewer.Uwp.MachineLearningSample/Models/Recommendation/RecommendationModel.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Data.DataView;
-using Microsoft.ML;
+﻿using Microsoft.ML;
 using Microsoft.ML.Data;
 using Mvvm;
 using System.Collections.Generic;
@@ -47,7 +46,7 @@ namespace XamlBrewer.Uwp.MachineLearningSample.Models
             var pipeline = _mlContext.Transforms.Conversion.MapValueToKey("Hotel")
                             .Append(_mlContext.Transforms.Conversion.MapValueToKey("TravelerType"))
                             .Append(_mlContext.Recommendation().Trainers.MatrixFactorization(
-                                              labelColumn: DefaultColumnNames.Label,
+                                              labelColumnName: "Label",
                                               matrixColumnIndexColumnName: "Hotel",
                                               matrixRowIndexColumnName: "TravelerType",
                                               // Optional fine tuning:
@@ -69,7 +68,7 @@ namespace XamlBrewer.Uwp.MachineLearningSample.Models
             // Place a breakpoint here to see the Schema.
             // var prediction = _model.Transform(trainingData);
 
-            predictionEngine = _model.CreatePredictionEngine<RecommendationData, RecommendationPrediction>(_mlContext);
+            predictionEngine = _mlContext.Model.CreatePredictionEngine<RecommendationData, RecommendationPrediction>(_model);
         }
 
         public RegressionMetrics Evaluate(string testDataPath)
@@ -98,14 +97,9 @@ namespace XamlBrewer.Uwp.MachineLearningSample.Models
         public void Save(string modelName)
         {
             var storageFolder = ApplicationData.Current.LocalFolder;
-            using (var fs = new FileStream(
-                    Path.Combine(storageFolder.Path, modelName),
-                    FileMode.Create,
-                    FileAccess.Write,
-                    FileShare.Write))
-            {
-                _model.SaveTo(_mlContext, fs);
-            }
+            string modelPath = Path.Combine(storageFolder.Path, modelName);
+
+            _mlContext.Model.Save(_model, inputSchema: null, filePath: modelPath);
         }
 
         public RecommendationPrediction Predict(RecommendationData recommendationData)

--- a/XamlBrewer.Uwp.MachineLearningSample/Models/Regression/RegressionModel.cs
+++ b/XamlBrewer.Uwp.MachineLearningSample/Models/Regression/RegressionModel.cs
@@ -47,10 +47,10 @@ namespace XamlBrewer.Uwp.MachineLearningSample.Models
                 .Append(_mlContext.Transforms.ReplaceMissingValues("Ws", "Ws", MissingValueReplacingEstimator.ReplacementMode.Mean))
                 .Append(_mlContext.Transforms.ReplaceMissingValues("Bmp", "Bmp", MissingValueReplacingEstimator.ReplacementMode.Mean))
                 .Append(_mlContext.Transforms.ReplaceMissingValues("NBA_DraftNumber", "NBA_DraftNumber", MissingValueReplacingEstimator.ReplacementMode.Mean))
-                .Append(_mlContext.Transforms.Normalize("NBA_DraftNumber", "NBA_DraftNumber", NormalizingEstimator.NormalizationMode.Binning))
-                .Append(_mlContext.Transforms.Normalize("Age", "Age", NormalizingEstimator.NormalizationMode.MinMax))
-                .Append(_mlContext.Transforms.Normalize("Ws", "Ws", NormalizingEstimator.NormalizationMode.MeanVariance))
-                .Append(_mlContext.Transforms.Normalize("Bmp", "Bmp", NormalizingEstimator.NormalizationMode.MeanVariance))
+                .Append(_mlContext.Transforms.NormalizeBinning("NBA_DraftNumber", "NBA_DraftNumber"))
+                .Append(_mlContext.Transforms.NormalizeMinMax("Age", "Age"))
+                .Append(_mlContext.Transforms.NormalizeMeanVariance("Ws", "Ws"))
+                .Append(_mlContext.Transforms.NormalizeMeanVariance("Bmp", "Bmp"))
                 .Append(_mlContext.Transforms.Concatenate(
                     "Features",
                     new[] { "NBA_DraftNumber", "Age", "Ws", "Bmp" }))

--- a/XamlBrewer.Uwp.MachineLearningSample/Models/Regression/RegressionModel.cs
+++ b/XamlBrewer.Uwp.MachineLearningSample/Models/Regression/RegressionModel.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Data.DataView;
-using Microsoft.ML;
+﻿using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Trainers;
 using Microsoft.ML.Transforms;
@@ -44,14 +43,14 @@ namespace XamlBrewer.Uwp.MachineLearningSample.Models
 
         public void BuildAndTrain()
         {
-            var pipeline = _mlContext.Transforms.ReplaceMissingValues("Age", "Age", MissingValueReplacingEstimator.ColumnOptions.ReplacementMode.Mean)
-                .Append(_mlContext.Transforms.ReplaceMissingValues("Ws", "Ws", MissingValueReplacingEstimator.ColumnOptions.ReplacementMode.Mean))
-                .Append(_mlContext.Transforms.ReplaceMissingValues("Bmp", "Bmp", MissingValueReplacingEstimator.ColumnOptions.ReplacementMode.Mean))
-                .Append(_mlContext.Transforms.ReplaceMissingValues("NBA_DraftNumber", "NBA_DraftNumber", MissingValueReplacingEstimator.ColumnOptions.ReplacementMode.Mean))
-                .Append(_mlContext.Transforms.Normalize("NBA_DraftNumber", "NBA_DraftNumber", NormalizingEstimator.NormalizerMode.Binning))
-                .Append(_mlContext.Transforms.Normalize("Age", "Age", NormalizingEstimator.NormalizerMode.MinMax))
-                .Append(_mlContext.Transforms.Normalize("Ws", "Ws", NormalizingEstimator.NormalizerMode.MeanVariance))
-                .Append(_mlContext.Transforms.Normalize("Bmp", "Bmp", NormalizingEstimator.NormalizerMode.MeanVariance))
+            var pipeline = _mlContext.Transforms.ReplaceMissingValues("Age", "Age", MissingValueReplacingEstimator.ReplacementMode.Mean)
+                .Append(_mlContext.Transforms.ReplaceMissingValues("Ws", "Ws", MissingValueReplacingEstimator.ReplacementMode.Mean))
+                .Append(_mlContext.Transforms.ReplaceMissingValues("Bmp", "Bmp", MissingValueReplacingEstimator.ReplacementMode.Mean))
+                .Append(_mlContext.Transforms.ReplaceMissingValues("NBA_DraftNumber", "NBA_DraftNumber", MissingValueReplacingEstimator.ReplacementMode.Mean))
+                .Append(_mlContext.Transforms.Normalize("NBA_DraftNumber", "NBA_DraftNumber", NormalizingEstimator.NormalizationMode.Binning))
+                .Append(_mlContext.Transforms.Normalize("Age", "Age", NormalizingEstimator.NormalizationMode.MinMax))
+                .Append(_mlContext.Transforms.Normalize("Ws", "Ws", NormalizingEstimator.NormalizationMode.MeanVariance))
+                .Append(_mlContext.Transforms.Normalize("Bmp", "Bmp", NormalizingEstimator.NormalizationMode.MeanVariance))
                 .Append(_mlContext.Transforms.Concatenate(
                     "Features",
                     new[] { "NBA_DraftNumber", "Age", "Ws", "Bmp" }))
@@ -59,24 +58,19 @@ namespace XamlBrewer.Uwp.MachineLearningSample.Models
                 // .Append(_mlContext.Regression.Trainers.OnlineGradientDescent(new OnlineGradientDescentTrainer.Options { })); // InvalidOperationException if you don't normalize.
                 // .Append(_mlContext.Regression.Trainers.StochasticDualCoordinateAscent());       
                 // .Append(_mlContext.Regression.Trainers.PoissonRegression());
-                .Append(_mlContext.Regression.Trainers.GeneralizedAdditiveModels());
+                .Append(_mlContext.Regression.Trainers.Gam());
 
             Model = pipeline.Fit(trainingData);
 
-            predictionEngine = Model.CreatePredictionEngine<RegressionData, RegressionPrediction>(_mlContext);
+            predictionEngine = _mlContext.Model.CreatePredictionEngine<RegressionData, RegressionPrediction>(Model);
         }
 
         public void Save(string modelName)
         {
             var storageFolder = ApplicationData.Current.LocalFolder;
-            using (var fs = new FileStream(
-                    Path.Combine(storageFolder.Path, modelName),
-                    FileMode.Create,
-                    FileAccess.Write,
-                    FileShare.Write))
-            {
-                Model.SaveTo(_mlContext, fs);
-            }
+            string modelPath = Path.Combine(storageFolder.Path, modelName);
+
+            _mlContext.Model.Save(Model, inputSchema: null, filePath: modelPath);
         }
 
         public IEnumerable<RegressionPrediction> PredictTrainingData()

--- a/XamlBrewer.Uwp.MachineLearningSample/ViewModels/BoxPlotPageViewModel.cs
+++ b/XamlBrewer.Uwp.MachineLearningSample/ViewModels/BoxPlotPageViewModel.cs
@@ -42,7 +42,7 @@ namespace XamlBrewer.Uwp.MachineLearningSample.ViewModels
                 for (int i = 0; i < dataView.Schema.Count; i++)
                 {
                     var column = dataView.Schema[i];
-                    result.Add(dataView.GetColumn<float>(_mlContext, column.Name).Select(f => (double)f).ToList());
+                    result.Add(dataView.GetColumn<float>(column).Select(f => (double)f).ToList());
                 }
 
                 return result;
@@ -72,7 +72,7 @@ namespace XamlBrewer.Uwp.MachineLearningSample.ViewModels
                 for (int i = 0; i < dataView.Schema.Count; i++)
                 {
                     var column = dataView.Schema[i];
-                    result.Add(dataView.GetColumn<float>(_mlContext, column.Name).Select(f => (double)f).ToList());
+                    result.Add(dataView.GetColumn<float>(column).Select(f => (double)f).ToList());
                 }
 
                 return result;

--- a/XamlBrewer.Uwp.MachineLearningSample/ViewModels/ClassificationPageViewModel.cs
+++ b/XamlBrewer.Uwp.MachineLearningSample/ViewModels/ClassificationPageViewModel.cs
@@ -33,7 +33,7 @@ namespace XamlBrewer.Uwp.MachineLearningSample.ViewModels
             });
         }
 
-        public Task<MultiClassClassifierMetrics> Evaluate(string testDataPath)
+        public Task<MulticlassClassificationMetrics> Evaluate(string testDataPath)
         {
             return Task.Run(() =>
             {

--- a/XamlBrewer.Uwp.MachineLearningSample/ViewModels/ClusteringPageViewModel.cs
+++ b/XamlBrewer.Uwp.MachineLearningSample/ViewModels/ClusteringPageViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Data.DataView;
+﻿using Microsoft.ML;
 using Mvvm;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/XamlBrewer.Uwp.MachineLearningSample/ViewModels/HeatMapPageViewModel.cs
+++ b/XamlBrewer.Uwp.MachineLearningSample/ViewModels/HeatMapPageViewModel.cs
@@ -38,7 +38,7 @@ namespace XamlBrewer.Uwp.MachineLearningSample.ViewModels
                 for (int i = 0; i < dataView.Schema.Count; i++)
                 {
                     var column = dataView.Schema[i];
-                    result.Add(dataView.GetColumn<float>(_mlContext, column.Name).Select(f => (double)f).ToList());
+                    result.Add(dataView.GetColumn<float>(column).Select(f => (double)f).ToList());
                 }
 
                 return result;

--- a/XamlBrewer.Uwp.MachineLearningSample/Views/BinaryClassificationPage.xaml
+++ b/XamlBrewer.Uwp.MachineLearningSample/Views/BinaryClassificationPage.xaml
@@ -38,7 +38,7 @@
         <TextBlock Grid.Row="1"
                    FontSize="24"
                    TextWrapping="WrapWholeWords"
-                   FontFamily="Segoe UI">Creates and compares four different models and a random one to predict the quality of wine using 11 physicochemical features.</TextBlock>
+                   FontFamily="Segoe UI">Creates and compares four different models and a "prior value" model to predict the quality of wine using 11 physicochemical features.</TextBlock>
 
         <!-- Main -->
         <Grid Grid.Row="2"

--- a/XamlBrewer.Uwp.MachineLearningSample/Views/BinaryClassificationPage.xaml.cs
+++ b/XamlBrewer.Uwp.MachineLearningSample/Views/BinaryClassificationPage.xaml.cs
@@ -14,7 +14,7 @@ namespace XamlBrewer.Uwp.MachineLearningSample
     public sealed partial class BinaryClassificationPage : Page
     {
         private string _testDataPath;
-        private PredictionModel<BinaryClassificationData, BinaryClassificationPrediction> _randomModel;
+        //private PredictionModel<BinaryClassificationData, BinaryClassificationPrediction> _priorModel;
         private PredictionModel<BinaryClassificationData, BinaryClassificationPrediction> _perceptronBinaryModel;
         private PredictionModel<BinaryClassificationData, BinaryClassificationPrediction> _linearSvmModel;
         private PredictionModel<BinaryClassificationData, BinaryClassificationPrediction> _logisticRegressionModel;
@@ -51,13 +51,14 @@ namespace XamlBrewer.Uwp.MachineLearningSample
             // Prepare diagram.
             PrepareDiagram(out ColumnSeries accuracySeries, out ColumnSeries entropySeries, out ColumnSeries f1ScoreSeries);
 
-            // Random
-            _randomModel = await ViewModel.BuildAndTrain(trainingDataLocation, ViewModel.MLContext.BinaryClassification.Trainers.Random());
-            await ViewModel.Save(_randomModel, "randomModel.zip");
-            var metrics = await ViewModel.Evaluate(_randomModel, _testDataPath);
-            accuracySeries.Items.Add(new ColumnItem { CategoryIndex = 0, Value = metrics.Accuracy });
-            entropySeries.Items.Add(new ColumnItem { CategoryIndex = 0, Value = metrics.Entropy });
-            f1ScoreSeries.Items.Add(new ColumnItem { CategoryIndex = 0, Value = metrics.F1Score });
+            // Prior
+            // blocked by https://github.com/dotnet/machinelearning/issues/3119
+            //_priorModel = await ViewModel.BuildAndTrain(trainingDataLocation, ViewModel.MLContext.BinaryClassification.Trainers.Prior());
+            //await ViewModel.Save(_priorModel, "priorModel.zip");
+            //var metrics = await ViewModel.Evaluate(_priorModel, _testDataPath);
+            //accuracySeries.Items.Add(new ColumnItem { CategoryIndex = 0, Value = metrics.Accuracy });
+            //entropySeries.Items.Add(new ColumnItem { CategoryIndex = 0, Value = metrics.Entropy });
+            //f1ScoreSeries.Items.Add(new ColumnItem { CategoryIndex = 0, Value = metrics.F1Score });
 
             // Perceptron
             PerceptronBox.IsChecked = true;
@@ -79,7 +80,7 @@ namespace XamlBrewer.Uwp.MachineLearningSample
 
             // Linear SVM
             LinearSvmBox.IsChecked = true;
-            _linearSvmModel = await ViewModel.BuildAndTrain(trainingDataLocation, ViewModel.MLContext.BinaryClassification.Trainers.LinearSupportVectorMachines());
+            _linearSvmModel = await ViewModel.BuildAndTrain(trainingDataLocation, ViewModel.MLContext.BinaryClassification.Trainers.LinearSvm());
             await ViewModel.Save(_linearSvmModel, "linearSvmModel.zip");
             nonCalibratedMetrics = await ViewModel.EvaluateNonCalibrated(_linearSvmModel, _testDataPath);
             accuracySeries.Items.Add(new ColumnItem { CategoryIndex = 2, Value = nonCalibratedMetrics.Accuracy });
@@ -91,9 +92,9 @@ namespace XamlBrewer.Uwp.MachineLearningSample
 
             // Logistic Regression
             LogisticRegressionBox.IsChecked = true;
-            _logisticRegressionModel = await ViewModel.BuildAndTrain(trainingDataLocation, ViewModel.MLContext.BinaryClassification.Trainers.LogisticRegression());
+            _logisticRegressionModel = await ViewModel.BuildAndTrain(trainingDataLocation, ViewModel.MLContext.BinaryClassification.Trainers.LbfgsLogisticRegression());
             await ViewModel.Save(_logisticRegressionModel, "logisticRegressionModel.zip");
-            metrics = await ViewModel.Evaluate(_logisticRegressionModel, _testDataPath);
+            var metrics = await ViewModel.Evaluate(_logisticRegressionModel, _testDataPath);
             accuracySeries.Items.Add(new ColumnItem { CategoryIndex = 3, Value = metrics.Accuracy });
             entropySeries.Items.Add(new ColumnItem { CategoryIndex = 3, Value = metrics.Entropy });
             f1ScoreSeries.Items.Add(new ColumnItem { CategoryIndex = 3, Value = metrics.F1Score });
@@ -103,7 +104,7 @@ namespace XamlBrewer.Uwp.MachineLearningSample
 
             // Stochastic Dual Coordinate Ascent
             SdcaBox.IsChecked = true;
-            _sdcabModel = await ViewModel.BuildAndTrain(trainingDataLocation, ViewModel.MLContext.BinaryClassification.Trainers.StochasticDualCoordinateAscent());
+            _sdcabModel = await ViewModel.BuildAndTrain(trainingDataLocation, ViewModel.MLContext.BinaryClassification.Trainers.SdcaLogisticRegression());
             await ViewModel.Save(_sdcabModel, "sdcabModel.zip");
             metrics = await ViewModel.Evaluate(_sdcabModel, _testDataPath);
             accuracySeries.Items.Add(new ColumnItem { CategoryIndex = 4, Value = metrics.Accuracy });
@@ -141,7 +142,7 @@ namespace XamlBrewer.Uwp.MachineLearningSample
                 Key = "ModelAxis",
                 ItemsSource = new[]
                     {
-                        "Random",
+                        "Prior",
                         "Perceptron",
                         "Linear SVM",
                         "Logistic Regression",

--- a/XamlBrewer.Uwp.MachineLearningSample/XamlBrewer.Uwp.MachineLearningSample.csproj
+++ b/XamlBrewer.Uwp.MachineLearningSample/XamlBrewer.Uwp.MachineLearningSample.csproj
@@ -291,10 +291,16 @@
       <Version>2.8.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ML">
-      <Version>0.11.0</Version>
+      <Version>0.12.0-preview-27526-3</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.ML.Experimental">
+      <Version>0.12.0-preview-27526-3</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.ML.FastTree">
+      <Version>0.12.0-preview-27526-3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ML.Recommender">
-      <Version>0.11.0</Version>
+      <Version>0.12.0-preview-27526-3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.8</Version>

--- a/XamlBrewer.Uwp.MachineLearningSample/XamlBrewer.Uwp.MachineLearningSample.csproj
+++ b/XamlBrewer.Uwp.MachineLearningSample/XamlBrewer.Uwp.MachineLearningSample.csproj
@@ -291,16 +291,13 @@
       <Version>2.8.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ML">
-      <Version>0.12.0-preview-27526-3</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ML.Experimental">
-      <Version>0.12.0-preview-27526-3</Version>
+      <Version>1.0.0-preview</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ML.FastTree">
-      <Version>0.12.0-preview-27526-3</Version>
+      <Version>1.0.0-preview</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ML.Recommender">
-      <Version>0.12.0-preview-27526-3</Version>
+      <Version>0.12.0-preview</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.8</Version>


### PR DESCRIPTION
I've updated the app to the latest released `1.0.0-preview` packages.

Note: `Microsoft.ML.Recommender` isn't going stable `1.0.0` when `Microsoft.ML` is going stable. So for now, using the latest `0.12.0-preview` version for that package. Recommender will become stable sometime in the future.

Also, note that the `Random` trainer is no longer available, so I tried using the `Prior` trainer instead. But that ran into an issue, so I commented out that trainer in the binary classification screen.

@XamlBrewer 